### PR TITLE
Support custom Docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ target host.
 
 The role is tested with vagrant:
 
-- Centos 7
 - Centos 8
 - Ubuntu 18.04
 - Ubuntu 20.04
 
-Currently not working on vagrant for RHEL 7+8 and Debian 9+10
+Currently not working on vagrant for Centos 7, RHEL 7+8 and Debian 9+10
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ repo](https://github.com/Telefonica/prometheus-kafka-adapter).
 Name|Default Value|Description
 ---|---|---
 `prometheus_kafka_adapter_config_dir`|/etc/prometheus-kafka-adapter|The config dir on the target host.
+`prometheus_kafka_adapter_docker_registry`|none|custom docker registry, no http/https or tailing slash, defaults to `registry.hub.docker.com`
+`prometheus_kafka_adapter_docker_username`|none|registry login username
+`prometheus_kafka_adapter_docker_password`|none|registry user password
 `prometheus_kafka_adapter_docker_image`|telefonica/prometheus-kafka-adapter:1.6.0|The Docker image to use for the adapter.
 `prometheus_kafka_adapter_container_name`|prometheus-kafka-adapter|The name of the container to be run on the target host.
 `prometheus_kafka_adapter_config_list`|[]|A list of prometheus-kafka-instances, for example one PKA per kafka topic.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,11 @@ prometheus_kafka_adapter_kafka_serialization_format: json
 prometheus_kafka_adapter_log_level: info
 prometheus_kafka_adapter_gin_mode: release
 
+# Placeholders for custom docker registry
+prometheus_kafka_adapter_docker_registry: 'registry.hub.docker.com'
+prometheus_kafka_adapter_docker_username: ''
+prometheus_kafka_adapter_docker_password: ''
+
 # Specify if certificates should be copied to the target
 prometheus_kafka_adapter_ssl_client_copy_files: false
 prometheus_kafka_adapter_ssl_client_cert_file: ""

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,9 +7,18 @@
     - "requests==2.20.0"
     - "docker==4.2.1"
 
+- name: prometheus_kafka_adapter | log into docker registry
+  docker_login:
+    registry: "{{ prometheus_kafka_adapter_docker_registry }}"
+    username: "{{ prometheus_kafka_adapter_docker_username }}"
+    password: "{{ prometheus_kafka_adapter_docker_password }}"
+  when:
+    - prometheus_kafka_adapter_docker_username != ''
+    - prometheus_kafka_adapter_docker_password != ''
+
 - name: Pull image
   docker_image:
-    name: "{{ prometheus_kafka_adapter_docker_image }}"
+    name: "{{prometheus_kafka_adapter_docker_registry}}/{{ prometheus_kafka_adapter_docker_image }}"
     source: pull
 
 - name: Configure kafka container as systemd services

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -3,13 +3,6 @@ Vagrant.configure("2") do |config|
         vb.memory = "1024" 
         vb.cpus = "1"
     end
-    
-    # CentOS 7 VM
-    config.vm.define "centos7" do |centos|
-      centos.vm.box = "centos/7"
-      centos.vm.provider "virtualbox" do |vb|
-      end
-    end
 
     # CentOS 8 VM
     config.vm.define "centos8" do |centos|
@@ -66,8 +59,7 @@ Vagrant.configure("2") do |config|
         ansible.playbook = "test.yml"
         #ansible.groups = {
         #}
-        ansible.host_vars = {
-          "centos7" => {"ansible_python_interpreter" => "/usr/bin/python2"}
-        }
+        #ansible.host_vars = {
+        #}
     end
 end

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,18 +13,6 @@
       become: false
       command: ansible-galaxy install geerlingguy.docker --roles-path roles
 
-    - name: Vagrant | Install python dependencies (CentOS7)
-      yum:
-        name: "{{ item }}"
-        state: present
-      loop:
-        - epel-release
-        - python-setuptools
-        - python-pip
-      when:
-        - ansible_os_family|lower == 'redhat'
-        - ansible_distribution_version|int <= 7
-
     - name: Vagrant | Install python dependencies (CentOS8)
       yum:
         name: "{{ item }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,6 +2,11 @@
 - hosts: all
   remote_user: root
 
+  vars:
+    # prometheus_kafka_adapter_docker_registry: ''
+    # ejbca_gemalto_docker_username: ''
+    # ejbca_gemalto_docker_password: ''
+
   pre_tasks:
     - name: install dependency galaxy role
       delegate_to: localhost


### PR DESCRIPTION
* Ending support for Centos 7 - vagrant test currently fails and won't be fixed
* Add configuration option to pull Docker image from a custom registry. See README for the new variables.